### PR TITLE
HILT Application class (#3)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="ir.whoisAbel.androidhilt">
 
     <application
+        android:name=".AndroidHiltApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/ir/whoisAbel/androidhilt/AndroidHiltApplication.kt
+++ b/app/src/main/java/ir/whoisAbel/androidhilt/AndroidHiltApplication.kt
@@ -1,0 +1,20 @@
+package ir.whoisAbel.androidhilt
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+
+/*
+   1. If you don't have an application class, you need to create one.
+
+   2. HILT must contain an Application class that is annotated
+   with @HiltAndroidApp annotation. It will trigger Hilt’s code generation.
+
+   3. Do not forget to add this application class in AndroidManifest.xml,
+    you need to update android:name in the AndroidManifest.xml
+
+*/
+
+@HiltAndroidApp
+class AndroidHiltApplication : Application() {
+}


### PR DESCRIPTION
1. If you don't have an **application** class, you need to create one. 
2. HILT must contain an Application class that is annotated with **@HiltAndroidApp** annotation. It will trigger Hilt’s code generation. 
3. Do not forget to add this application class in **AndroidManifest.xml**, you need to update **android:name** in the AndroidManifest.xml